### PR TITLE
HTTPS for affinity images and links. 

### DIFF
--- a/site-src/affinity/index.html
+++ b/site-src/affinity/index.html
@@ -17,14 +17,14 @@ You're welcome to copy the images to your own web page if you prefer.
   <hr>
 
 <p>
-<a href="http://www.p27.eu/"><img alt="p27 europe"
+<a href="https://www.p27.eu/"><img alt="p27 europe"
 src="p27-europe-small.png"></a>
 <p>
-<code>&lt;a href="http://www.p27.eu/"&gt;
-&lt;img alt="p27 europe" src="http://www.p27.eu/affinity/p27-europe-small.png"&gt;&lt;/a&gt;</code>
+<code>&lt;a href="https://www.p27.eu/"&gt;
+&lt;img alt="p27 europe" src="https://www.p27.eu/affinity/p27-europe-small.png"&gt;&lt;/a&gt;</code>
 <br>
-<code>&lt;a href="http://www.p27.eu/"&gt;
-&lt;img alt="p27 europe" src="http://www.p27.eu/affinity/p27-europe-large.png"&gt;&lt;/a&gt;</code>
+<code>&lt;a href="https://www.p27.eu/"&gt;
+&lt;img alt="p27 europe" src="https://www.p27.eu/affinity/p27-europe-large.png"&gt;&lt;/a&gt;</code>
 </p><hr>
 
 <p>


### PR DESCRIPTION
http doesnt load nicely on an https page
https loads fine on http pages
better to use https